### PR TITLE
Show date tooltip on elapsed time

### DIFF
--- a/handlers/documentationview.py
+++ b/handlers/documentationview.py
@@ -74,6 +74,7 @@ class DocumentationViewHandler(BaseRequestHandler):
         fmt = util.get_format(respctype) if respctype else None
 
         self.render("one.html", 
+                tz=self.TZ,
                 item=entry, 
                 body=resbody,
                 fmt=fmt,

--- a/handlers/view.py
+++ b/handlers/view.py
@@ -100,6 +100,7 @@ class ViewHandler(BaseRequestHandler):
         fmt = util.get_format(util.get_content_type(self.nice_headers(responseheaders))) if responseheaders else None
 
         self.render("one.html", 
+                tz=self.TZ,
                 item=entry, 
                 cmd=cmd,
                 body=resbody,

--- a/templates/one.html
+++ b/templates/one.html
@@ -20,7 +20,7 @@
 </span>
 
       <div class="top-right">
-          <span class="time">{{ relativedelta(seconds=item['request']['time']).normalized().microseconds/1000 }}ms</span>
+        <span class="time" title="{{ item['date'].astimezone(tz).strftime('%F %H:%M:%S') }}">{{ relativedelta(seconds=item['request']['time']).normalized().microseconds/1000 }}ms</span>
       </div>
 </h2>
 


### PR DESCRIPTION
The date of the request is not displayed anywhere on the view page. This adds it as a tooltip on the elapsed time